### PR TITLE
refactor: improve resizing methods of the Deque~T~ class

### DIFF
--- a/src/Yuh.Collections.Tests/DequeTest.cs
+++ b/src/Yuh.Collections.Tests/DequeTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+
+namespace Yuh.Collections.Tests
+{
+    public class DequeTest(ITestOutputHelper @out)
+    {
+        private readonly ITestOutputHelper _out = @out;
+
+        [Fact]
+        public void GrowTest()
+        {
+            Deque<int> deque = new(6);
+
+            deque.PushBack(0);
+            deque.PushBack(1);
+            deque.PushBack(2);
+            OutputCapacityAndMargin(deque);
+
+            deque.PushBack(3);
+            OutputCapacityAndMargin(deque);
+
+            deque.PushFront(4);
+            OutputCapacityAndMargin(deque);
+
+            deque.PushFront(5);
+            OutputCapacityAndMargin(deque);
+
+            deque.PushFront(6);
+            OutputCapacityAndMargin(deque);
+
+            deque.PushFront(7);
+            OutputCapacityAndMargin(deque);
+
+            Deque<int> deque2 = new([0, 1, 2, 3]);
+            deque2.EnsureCapacity(8);
+            OutputCapacityAndMargin(deque2);
+
+            Deque<int> deque3 = new([0, 1, 2, 3]);
+            deque3.EnsureCapacity(1, 2);
+            OutputCapacityAndMargin(deque3);
+        }
+
+        internal void OutputCapacityAndMargin(Deque<int> deque, [CallerArgumentExpression(nameof(deque))] string? argName = null)
+        {
+            _out.WriteLine($"{argName}: {deque.Capacity}, {deque.FrontMargin}, {deque.BackMargin}");
+        }
+    }
+}

--- a/src/Yuh.Collections.Tests/OutputHelpers.cs
+++ b/src/Yuh.Collections.Tests/OutputHelpers.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 using Xunit.Abstractions;
 
 namespace Yuh.Collections.Tests

--- a/src/Yuh.Collections.Tests/OutputHelpers.cs
+++ b/src/Yuh.Collections.Tests/OutputHelpers.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Yuh.Collections.Tests
+{
+    internal static class OutputHelpers
+    {
+        internal static void OutputElements<T>(IEnumerable<T> buffer, ITestOutputHelper @out)
+        {
+            StringBuilder sb = new();
+
+            foreach (var v in buffer)
+            {
+                sb.Append(v?.ToString()).Append('\x20');
+            }
+
+            @out.WriteLine(sb.ToString());
+        }
+    }
+}

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -302,12 +302,44 @@ namespace Yuh.Collections
 
             if ((frontMargin, backMargin) == (FrontMargin, BackMargin))
             {
+        /// <remarks>
+        /// If <paramref name="capacity"/> is greater than <see cref="Array.MaxLength"/>, this does NOT throw any exceptions and treats <paramref name="capacity"/> as equal to <see cref="Array.MaxLength"/>.
+        /// </remarks>
+        private void EnsureCapacityInternal(int capacity)
+        {
+            if (capacity <= _items.Length)
+            {
                 return;
             }
 
-            int newFrontMargin = Math.Max(frontMargin, this.FrontMargin);
-            int newBackMargin = Math.Max(backMargin, this.BackMargin);
-            Resize(newFrontMargin, newBackMargin);
+            int newCapacity = Math.Min(Math.Max(_items.Length << 1, capacity), Array.MaxLength);
+
+            Grow(newCapacity);
+        }
+
+        /// <remarks>
+        /// This does NOT examine whether the total required capacity is valid (between 0 and <see cref="Array.MaxLength"/>.)
+        /// </remarks>
+        private void EnsureCapacityInternal(int frontMargin, int backMargin)
+        {
+            if (frontMargin <= this.FrontMargin && backMargin <= this.BackMargin)
+            {
+                return;
+            }
+
+            int neededCapacity = frontMargin + backMargin + _count;
+            int doubledCapacity = Math.Min(_items.Length << 1, Array.MaxLength);
+
+            if (neededCapacity >= doubledCapacity)
+            {
+                ResizeInternal(neededCapacity, frontMargin);
+            }
+            else
+            {
+                int capacityDiff = doubledCapacity - neededCapacity; // this is always positive.
+                int marginDiff = Math.Clamp(-capacityDiff, (frontMargin - backMargin), capacityDiff);
+                ResizeInternal(doubledCapacity, frontMargin + capacityDiff + marginDiff);
+            }
         }
 
         /// <summary>

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -278,13 +278,13 @@ namespace Yuh.Collections
         /// </summary>
         /// <param name="capacity">The number of elements that the <see cref="Deque{T}"/> can hold without resizing.</param>
         /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative or greater than <see cref="Array.MaxLength"/>.</exception>
         public void EnsureCapacity(int capacity)
         {
             ThrowHelpers.ThrowIfArgumentIsNegative(capacity);
             ThrowHelpers.ThrowIfArgumentIsGreaterThanMaxArrayLength(capacity);
             EnsureCapacityInternal(capacity);
             }
-        }
 
         /// <summary>
         /// Ensures that the margins at the beginning and back of the <see cref="Deque{T}"/> are respectively at least those specified.
@@ -758,9 +758,6 @@ namespace Yuh.Collections
         /// <summary>
         /// Enlarge the internal array to twice its size.
         /// </summary>
-        /// <remarks>
-        /// This reduces the margin at the less-frequently-used end by half and gives the remaining capacity to another end.
-        /// </remarks>
         private void Grow()
         {
             int newCapacity = Math.Clamp(_items.Length << 1, _defaultCapacity, Array.MaxLength);

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -836,6 +836,11 @@ namespace Yuh.Collections
             }
         }
 
+        /// <summary>
+        /// Creates a new array as an internal array at the specified size, and copies to the array all the elements contained in the <see cref="Deque{T}"/>.
+        /// </summary>
+        /// <param name="capacity"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ResizeInternal(int capacity)
         {
             if (capacity == 0)

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -723,26 +723,6 @@ namespace Yuh.Collections
         /// <summary>
         /// Enlarge the internal array to twice its size.
         /// </summary>
-        /// <exception cref="Exception">The number of elements contained in the <see cref="Deque{T}"/> has reached its upper limit.</exception>
-        private void Grow()
-        {
-            // 値を [_defaultCapacity, Array.MaxLength] に収める.
-            int newCapacity = Math.Min(
-                    Math.Max(_items.Length << 1, _defaultCapacity),
-                    Array.MaxLength
-                    );
-
-            if (newCapacity < _count + 2)
-            {
-                throw new Exception(ThrowHelpers.M_CapacityReachedUpperLimit);
-            }
-
-            ResizeInternal(newCapacity);
-        }
-
-        /// <summary>
-        /// Enlarge the internal array to twice its size.
-        /// </summary>
         /// <remarks>
         /// This reduces the margin at the less-frequently-used end by half and gives the remaining capacity to another end.
         /// </remarks>
@@ -798,7 +778,7 @@ namespace Yuh.Collections
                     // shift the elements in [0, index) of the deque.
                     if (_head == 0)
                     {
-                        Grow();
+                        GrowImproved();
                     }
 
                     var span = MemoryMarshal.CreateSpan(ref _items[_head - 1], index + 1);
@@ -815,7 +795,7 @@ namespace Yuh.Collections
                     // shifts the elements in [index, _count) of the deque.
                     if (_items.Length - _head - _count == 0) // _head + _count == _items.Length
                     {
-                        Grow();
+                        GrowImproved();
                     }
 
                     var span = MemoryMarshal.CreateSpan(ref _items[_head + index], _count - index + 1);

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -503,7 +503,7 @@ namespace Yuh.Collections
 
             if (index == _items.Length)
             {
-                Grow();
+                GrowImproved();
             }
 
             index = _head + _count;
@@ -523,7 +523,7 @@ namespace Yuh.Collections
         {
             if (_head == 0)
             {
-                Grow();
+                GrowImproved();
             }
 
             _items[--_head] = item;

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -766,16 +766,15 @@ namespace Yuh.Collections
                     break;
                 }
 
-                case < 0: // frontMargin < backMargin
+                case < 0: // frontMargin < backMargin (the front is more frequently used)
                 {
-                    ResizeInternal(newCapacity, (frontMargin + 1) >> 1);
+                    ResizeInternal(newCapacity, newCapacity - _count - ((backMargin + 1) >> 1));
                     break;
                 }
 
-                default: // frontMargin > backMargin
+                default: // frontMargin > backMargin (the back is more frequently used)
                 {
-                    backMargin >>= 1;
-                    ResizeInternal(newCapacity, newCapacity - _count - ((backMargin + 1) >> 1));
+                    ResizeInternal(newCapacity, (frontMargin + 1) >> 1);
                     break;
                 }
             }

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -503,7 +503,7 @@ namespace Yuh.Collections
 
             if (index == _items.Length)
             {
-                GrowImproved();
+                Grow();
             }
 
             index = _head + _count;
@@ -523,7 +523,7 @@ namespace Yuh.Collections
         {
             if (_head == 0)
             {
-                GrowImproved();
+                Grow();
             }
 
             _items[--_head] = item;
@@ -726,7 +726,7 @@ namespace Yuh.Collections
         /// <remarks>
         /// This reduces the margin at the less-frequently-used end by half and gives the remaining capacity to another end.
         /// </remarks>
-        private void GrowImproved()
+        private void Grow()
         {
             int newCapacity = Math.Clamp(_items.Length << 1, _defaultCapacity, Array.MaxLength);
 
@@ -778,7 +778,7 @@ namespace Yuh.Collections
                     // shift the elements in [0, index) of the deque.
                     if (_head == 0)
                     {
-                        GrowImproved();
+                        Grow();
                     }
 
                     var span = MemoryMarshal.CreateSpan(ref _items[_head - 1], index + 1);
@@ -795,7 +795,7 @@ namespace Yuh.Collections
                     // shifts the elements in [index, _count) of the deque.
                     if (_items.Length - _head - _count == 0) // _head + _count == _items.Length
                     {
-                        GrowImproved();
+                        Grow();
                     }
 
                     var span = MemoryMarshal.CreateSpan(ref _items[_head + index], _count - index + 1);

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -274,7 +274,7 @@ namespace Yuh.Collections
 
         /// <summary>
         ///     Ensures that the capacity of this <see cref="Deque{T}"/> is at least the specified one.
-        ///     If the current capacity is less than the specified one, resizes the internal array for the <see cref="Deque{T}"/> to be able to accommodate the specified number of elements without resizing.
+        ///     If the current capacity is less than the specified one, resizes the internal array so that the <see cref="Deque{T}"/> can accommodate the specified number of elements without resizing.
         /// </summary>
         /// <param name="capacity">The number of elements that the <see cref="Deque{T}"/> can hold without resizing.</param>
         /// <returns></returns>

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -284,7 +284,7 @@ namespace Yuh.Collections
             ThrowHelpers.ThrowIfArgumentIsNegative(capacity);
             ThrowHelpers.ThrowIfArgumentIsGreaterThanMaxArrayLength(capacity);
             EnsureCapacityInternal(capacity);
-            }
+        }
 
         /// <summary>
         /// Ensures that the margins at the beginning and back of the <see cref="Deque{T}"/> are respectively at least those specified.
@@ -768,14 +768,14 @@ namespace Yuh.Collections
             }
 
             Grow(newCapacity);
-                }
+        }
 
         /// <summary>
         /// Enlarge the internal array to the specified size.
         /// </summary>
         /// <param name="capacity"></param>
         private void Grow(int capacity)
-                {
+        {
             int frontMargin = FrontMargin;
             int backMargin = BackMargin;
 

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -843,10 +843,8 @@ namespace Yuh.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ResizeInternal(int capacity)
         {
-            if (capacity == 0)
-            {
-                _items = _s_emptyArray;
-                _head = 0;
+            int frontMargin = (capacity - _count) >> 1;
+            ResizeInternal(capacity, frontMargin);
             }
             else
             {

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -770,15 +770,7 @@ namespace Yuh.Collections
                 ThrowHelpers.ThrowException(ThrowHelpers.M_CapacityReachedUpperLimit);
             }
 
-            int frontMargin = FrontMargin;
-            int backMargin = BackMargin;
-
-            switch (frontMargin - backMargin)
-            {
-                case 0: // frontMargin == backMargin
-                {
-                    ResizeInternal(newCapacity);
-                    break;
+            Grow(newCapacity);
                 }
 
         /// <summary>

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -282,10 +282,7 @@ namespace Yuh.Collections
         {
             ThrowHelpers.ThrowIfArgumentIsNegative(capacity);
             ThrowHelpers.ThrowIfArgumentIsGreaterThanMaxArrayLength(capacity);
-
-            if (capacity > _items.Length)
-            {
-                Resize(capacity);
+            EnsureCapacityInternal(capacity);
             }
         }
 
@@ -300,8 +297,14 @@ namespace Yuh.Collections
             ThrowHelpers.ThrowIfArgumentIsNegative(frontMargin);
             ThrowHelpers.ThrowIfArgumentIsNegative(backMargin);
 
-            if ((frontMargin, backMargin) == (FrontMargin, BackMargin))
+            if (frontMargin + backMargin + _count > Array.MaxLength)
             {
+                ThrowHelpers.ThrowArgumentException("The total needed capacity is greater than `Array.MaxLength`.", "{ frontMargin, backMargin }");
+            }
+
+            EnsureCapacityInternal(frontMargin, backMargin);
+        }
+
         /// <remarks>
         /// If <paramref name="capacity"/> is greater than <see cref="Array.MaxLength"/>, this does NOT throw any exceptions and treats <paramref name="capacity"/> as equal to <see cref="Array.MaxLength"/>.
         /// </remarks>

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -913,7 +913,7 @@ namespace Yuh.Collections
         }
 
         /// <summary>
-        /// Shifts all the elements in the internal data structure at specified time/times.
+        /// Shifts all the elements in the internal data structure at specified time(s).
         /// </summary>
         /// <remarks>
         /// This doesn't check whether <paramref name="diff"/> is valid or not.

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -340,8 +340,8 @@ namespace Yuh.Collections
             else
             {
                 int capacityDiff = doubledCapacity - neededCapacity; // this is always positive.
-                int marginDiff = Math.Clamp(-capacityDiff, (frontMargin - backMargin), capacityDiff);
-                ResizeInternal(doubledCapacity, frontMargin + capacityDiff + marginDiff);
+                int marginDiff = Math.Clamp(-capacityDiff, (backMargin - frontMargin), capacityDiff);
+                ResizeInternal(doubledCapacity, frontMargin + ((capacityDiff + marginDiff) >> 1));
             }
         }
 
@@ -776,11 +776,8 @@ namespace Yuh.Collections
         /// <param name="capacity"></param>
         private void Grow(int capacity)
         {
-            int frontMargin = FrontMargin;
-            int backMargin = BackMargin;
-
-            int diff = frontMargin - backMargin;
-            ResizeInternal(capacity, ((capacity - _count) >> 1) + diff);
+            int diff = BackMargin - FrontMargin;
+            ResizeInternal(capacity, ((capacity - _count + diff) >> 1));
         }
 
         private void InsertInternal(int index, T item)

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -620,7 +620,7 @@ namespace Yuh.Collections
                 throw new ArgumentException("The total required capacity is greater than the maximum size of an array.");
             }
 
-            ResizeInternal(frontMargin, backMargin);
+            ResizeInternal(capacity, frontMargin);
         }
 
         /// <summary>
@@ -628,7 +628,7 @@ namespace Yuh.Collections
         /// </summary>
         public void ShrinkToFit()
         {
-            ResizeInternal(0, 0);
+            ResizeInternal(_count, 0);
         }
 
         /// <summary>
@@ -849,29 +849,25 @@ namespace Yuh.Collections
                 T[] newArray = new T[capacity];
                 Array.Copy(_items, _head, newArray, newHead, _count);
 
-                _items = newArray;
-                _head = newHead;
-            }
-
-            _version++;
-        }
-
-        private void ResizeInternal(int frontExtraCapacity, int backExtraCapacity)
+        /// <summary>
+        /// Creates a new array as an internal array at the specified size, and copies to the array starting at the specified index all the elements contained in the <see cref="Deque{T}"/>.
+        /// </summary>
+        /// <param name="capacity"></param>
+        /// <param name="frontMargin"></param>
+        private void ResizeInternal(int capacity, int frontMargin)
         {
-            int newCapacity = frontExtraCapacity + _count + backExtraCapacity;
-
-            if (newCapacity == 0)
+            if (capacity == 0)
             {
                 _items = _s_emptyArray;
                 _head = 0;
             }
             else
             {
-                T[] newArray = new T[newCapacity];
-                Array.Copy(_items, _head, newArray, frontExtraCapacity, _count);
+                T[] newArray = new T[capacity];
+                Array.Copy(_items, _head, newArray, frontMargin, _count);
 
                 _items = newArray;
-                _head = frontExtraCapacity;
+                _head = frontMargin;
             }
 
             _version++;

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -781,18 +781,17 @@ namespace Yuh.Collections
                     break;
                 }
 
-                case < 0: // frontMargin < backMargin (the front is more frequently used)
+        /// <summary>
+        /// Enlarge the internal array to the specified size.
+        /// </summary>
+        /// <param name="capacity"></param>
+        private void Grow(int capacity)
                 {
-                    ResizeInternal(newCapacity, newCapacity - _count - ((backMargin + 1) >> 1));
-                    break;
-                }
+            int frontMargin = FrontMargin;
+            int backMargin = BackMargin;
 
-                default: // frontMargin > backMargin (the back is more frequently used)
-                {
-                    ResizeInternal(newCapacity, (frontMargin + 1) >> 1);
-                    break;
-                }
-            }
+            int diff = frontMargin - backMargin;
+            ResizeInternal(capacity, ((capacity - _count) >> 1) + diff);
         }
 
         private void InsertInternal(int index, T item)

--- a/src/Yuh.Collections/ThrowHelpers.cs
+++ b/src/Yuh.Collections/ThrowHelpers.cs
@@ -24,6 +24,13 @@ namespace Yuh.Collections
             throw new Exception(message, innerException);
         }
 
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ThrowArgumentException(string? message = null, string? argName = null, Exception? innerException = null)
+        {
+            throw new ArgumentException(message, argName, innerException);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ThrowIfArgumentIsGreaterThanMaxArrayLength(int num, [CallerArgumentExpression(nameof(num))] string? argName = null)
         {

--- a/src/Yuh.Collections/ThrowHelpers.cs
+++ b/src/Yuh.Collections/ThrowHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Yuh.Collections
 {
@@ -15,6 +16,13 @@ namespace Yuh.Collections
         internal const string M_TypeOfValueNotSupported = "The type of the value is not supported.";
 
         internal const string M_ValueIsNegative = "The value is negative.";
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ThrowException(string? message = null, Exception? innerException = null)
+        {
+            throw new Exception(message, innerException);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ThrowIfArgumentIsGreaterThanMaxArrayLength(int num, [CallerArgumentExpression(nameof(num))] string? argName = null)


### PR DESCRIPTION
## Summary

Improve resizing method of the `Deque<T>` class.

## What I did?

- Adopted an algorithm that determine the amount of margin to be allocated to each end (front and back) based on the amount of remaining margin at each end.
- Added new internal methods to the `Deque<T>` class.
  - `EnsureCapacityInternal(int)`
  - `EnsureCapacityInternal(int, int)`
  - `Grow(int)`

## Why?

`Deque<T>` used to allocate margin evenly to each end (front and back), so it could occupy much unnecessary memory region.

These changes contribute to saving memory used by `Deque<T>`.

## How?

- Added new internal methods and rewrite some methods.

## Testing

- Tested new methods in the `Yuh.Collections.Tests.DequeTest` class.