### PR TITLE
Feat: specialized adding method for ICollection{T}

### DIFF
--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -115,7 +115,7 @@ namespace Yuh.Collections
                 AddICollectionRangeInternal(collection);
             }
             else
-                {
+            {
                 AddIEnumerableRange(items);
             }
         }
@@ -361,7 +361,9 @@ namespace Yuh.Collections
         [InlineArray(SegmentsCount)]
         private struct SegmentsArray
         {
+#pragma warning disable IDE0051, IDE0044
             private T[] _value;
+#pragma warning restore IDE0051, IDE0044
         }
 #endif
     }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -115,19 +115,13 @@ namespace Yuh.Collections
         {
             ArgumentNullException.ThrowIfNull(items);
 
-            var currentSegment = _currentSegment;
-
-            foreach (var item in items)
+            if (items is ICollection<T> collection)
             {
-                if (_countInCurrentSegment == currentSegment.Length)
+                AddICollectionRangeInternal(collection);
+            }
+            else
                 {
-                    Grow();
-                    currentSegment = _currentSegment;
-                }
-
-                currentSegment[_countInCurrentSegment] = item;
-                _countInCurrentSegment++;
-                _count++;
+                AddIEnumerableRange(items);
             }
         }
 

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -327,7 +327,7 @@ namespace Yuh.Collections
         }
 
 #if NET8_0_OR_GREATER
-        [InlineArray(27)]
+        [InlineArray(SegmentsCount)]
         private struct SegmentsArray
         {
             private T[] _value;

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -116,7 +116,7 @@ namespace Yuh.Collections
         }
 
         /// <summary>
-        /// Adds elements in a <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// Adds elements in an <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="items">An <see cref="IEnumerable{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -135,12 +135,12 @@ namespace Yuh.Collections
         }
 
         /// <summary>
-        /// Adds elements in a <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// Adds elements in an <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <remarks>
         /// This implementation assumes that <paramref name="items"/> is NOT <see cref="ICollection{T}"/> and thus doesn't check if it is.
         /// </remarks>
-        /// <param name="items"></param>
+        /// <param name="items">An <see cref="IEnumerable{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddIEnumerableRange(IEnumerable<T> items)
         {

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -131,7 +131,7 @@ namespace Yuh.Collections
         /// Adds elements in the span to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="items">A span over elements to add.</param>
-        /// <exception cref="ArgumentException">The <see cref="CollectionBuilder{T}"/> doesn't have enough space to accomodate elements contained in <paramref name="items"/>.</exception>
+        /// <exception cref="ArgumentException">The <see cref="CollectionBuilder{T}"/> doesn't have enough space to accommodate elements contained in <paramref name="items"/>.</exception>
         public void AddRange(ReadOnlySpan<T> items)
         {
             if (items.Length == 0)
@@ -141,7 +141,7 @@ namespace Yuh.Collections
 
             if (items.Length > Array.MaxLength - _count) // use this way to avoid overflow
             {
-                ThrowHelpers.ThrowArgumentException("This collection doesn't have enough space to accomodate elements of the specified span.", nameof(items));
+                ThrowHelpers.ThrowArgumentException("This collection doesn't have enough space to accommodate elements of the specified span.", nameof(items));
             }
 
             int newCount = _count + items.Length;
@@ -188,7 +188,7 @@ namespace Yuh.Collections
         /// Copies elements in the <see cref="CollectionBuilder{T}"/> to the specified span.
         /// </summary>
         /// <param name="destination"></param>
-        /// <exception cref="ArgumentException"><paramref name="destination"/> doesn't have enough space to accomodate elements copied.</exception>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> doesn't have enough space to accommodate elements copied.</exception>
         public readonly void CopyTo(Span<T> destination)
         {
             if (_count == 0)
@@ -198,7 +198,7 @@ namespace Yuh.Collections
 
             if (destination.Length < _count)
             {
-                ThrowHelpers.ThrowArgumentException("The destination span doesn't have enough space to accomodate elements in this collection.", nameof(destination));
+                ThrowHelpers.ThrowArgumentException("The destination span doesn't have enough space to accommodate elements in this collection.", nameof(destination));
             }
 
             int remainsCount = _count;

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -223,15 +223,7 @@ namespace Yuh.Collections
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Grow()
-        {
-            var nextSegment = GC.AllocateUninitializedArray<T>(_nextSegmentLength);
-            _segments[_allocatedCount] = nextSegment;
-
-            _allocatedCount++;
-            _currentSegment = nextSegment.AsSpan();
-            _countInCurrentSegment = 0;
-            _nextSegmentLength <<= 1;
-        }
+            => GrowExact(_nextSegmentLength);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GrowExact(int length)

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -223,7 +223,7 @@ namespace Yuh.Collections
 
                 segment.AsSpan().CopyTo(MemoryMarshal.CreateSpan(ref destRef, segmentLength));
                 destRef = ref Unsafe.Add(ref Unsafe.AsRef(in destRef), segmentLength);
-                remainsCount -= segment.Length;
+                remainsCount -= segmentLength;
             }
         }
 

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -292,23 +292,6 @@ namespace Yuh.Collections
             _nextSegmentLength <<= 1;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ResizeCurrentSegment(int length)
-        {
-            var newSegment = GC.AllocateUninitializedArray<T>(length);
-            var countInNewSegment = Math.Min(length, _currentSegment.Length);
-            ref var currentSegmentRef = ref MemoryMarshal.GetReference(_currentSegment);
-
-            MemoryMarshal.CreateReadOnlySpan(ref currentSegmentRef, countInNewSegment).CopyTo(newSegment);
-            CollectionHelpers.ClearIfReferenceOrContainsReferences(
-                MemoryMarshal.CreateSpan(ref currentSegmentRef, _countInCurrentSegment)
-            );
-
-            _segments[_allocatedCount - 1] = newSegment;
-            _currentSegment = newSegment.AsSpan();
-            _countInCurrentSegment = countInNewSegment;
-        }
-
         [method: MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ExpandCurrentSegment(int length)
         {

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -68,18 +68,6 @@ namespace Yuh.Collections
             _count++;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Grow()
-        {
-            var nextSegment = GC.AllocateUninitializedArray<T>(_nextSegmentLength);
-            _segments[_allocatedCount] = nextSegment;
-
-            _allocatedCount++;
-            _currentSegment = nextSegment.AsSpan();
-            _countInCurrentSegment = 0;
-            _nextSegmentLength <<= 1;
-        }
-
         /// <summary>
         /// Adds elements in a <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
@@ -231,6 +219,18 @@ namespace Yuh.Collections
                 destRef = ref Unsafe.Add(ref Unsafe.AsRef(in destRef), segmentLength);
                 remainsCount -= segment.Length;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Grow()
+        {
+            var nextSegment = GC.AllocateUninitializedArray<T>(_nextSegmentLength);
+            _segments[_allocatedCount] = nextSegment;
+
+            _allocatedCount++;
+            _currentSegment = nextSegment.AsSpan();
+            _countInCurrentSegment = 0;
+            _nextSegmentLength <<= 1;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -226,6 +226,10 @@ namespace Yuh.Collections
             => GrowExact(_nextSegmentLength);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Grow(int neededLength)
+            => GrowExact(Math.Min(neededLength, _nextSegmentLength));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GrowExact(int length)
         {
             var newSegment = GC.AllocateUninitializedArray<T>(length);

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -10,7 +10,7 @@ namespace Yuh.Collections
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     public ref struct CollectionBuilder<T>// : IDisposable
     {
-        public const int SegmentsCount = 27;
+        private const int SegmentsCount = 27;
 
         /// <summary>
         /// The minimum length of each segments.

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -12,6 +12,9 @@ namespace Yuh.Collections
     {
         public const int SegmentsCount = 27;
 
+        /// <summary>
+        /// The minimum length of each segments.
+        /// </summary>
         public const int MinSegmentLength = 16;
 
         private int _allocatedCount = 0; // in the range [0, 27]
@@ -31,8 +34,15 @@ namespace Yuh.Collections
         /// </summary>
         public readonly int Count => _count;
 
+        /// <summary>
+        /// Initializes a collection builder whose fields are set to default value.
+        /// </summary>
         public CollectionBuilder() { }
 
+        /// <summary>
+        /// Initializes a collection builder whose first segment can contain exactly specified number of elements.
+        /// </summary>
+        /// <param name="firstSegmentLength">The number of elements that can be contained in the first segment.</param>
         public CollectionBuilder(int firstSegmentLength)
         {
             if (firstSegmentLength < MinSegmentLength || Array.MaxLength < firstSegmentLength)
@@ -64,6 +74,10 @@ namespace Yuh.Collections
             _count++;
         }
 
+        /// <summary>
+        /// Adds elements in an <see cref="ICollection{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>
+        /// </summary>
+        /// <param name="items">An <see cref="ICollection{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddICollectionRange(ICollection<T> items)
         {
@@ -325,6 +339,10 @@ namespace Yuh.Collections
             CollectionHelpers.ClearIfReferenceOrContainsReferences(src);
         }
 
+        /// <summary>
+        /// Creates an array from the <see cref="CollectionBuilder{T}"/> and returns it.
+        /// </summary>
+        /// <returns>An array which contains elements copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly T[] ToArray()
         {
@@ -338,6 +356,10 @@ namespace Yuh.Collections
             return array;
         }
 
+        /// <summary>
+        /// Creates an <see cref="List{T}"/> from the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <returns>A <see cref="List{T}"/> which contains elements copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly List<T> ToList()
         {

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -233,7 +233,7 @@ namespace Yuh.Collections
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Grow(int neededLength)
-            => GrowExact(Math.Min(neededLength, _nextSegmentLength));
+            => GrowExact(Math.Max(neededLength, _nextSegmentLength));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GrowExact(int length)

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -5,7 +5,7 @@ using SysCollectionsMarshal = System.Runtime.InteropServices.CollectionsMarshal;
 namespace Yuh.Collections
 {
     /// <summary>
-    /// Repreents a temporary collection that is used to build new collections.
+    /// Represents a temporary collection that is used to build new collections.
     /// </summary>
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     public ref struct CollectionBuilder<T>// : IDisposable

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -21,7 +21,7 @@ namespace Yuh.Collections
 #if NET8_0_OR_GREATER
         private SegmentsArray _segments;
 #else
-        private readonly T[][] _segments;
+        private readonly T[][] _segments = new T[SegmentsCount][];
 #endif
 
         /// <summary>

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -104,6 +104,20 @@ namespace Yuh.Collections
         }
 
         /// <summary>
+        /// Adds elements in a <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// This implementation assumes that <paramref name="items"/> is NOT <see cref="ICollection{T}"/> and thus doesn't check if it is.
+        /// </remarks>
+        /// <param name="items"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AddNonICollectionRange(IEnumerable<T> items)
+        {
+            ArgumentNullException.ThrowIfNull(items);
+            AddNonICollectionRangeInternal(items);
+        }
+
+        /// <remarks>
         /// This doesn't check if <paramref name="items"/> is null.
         /// </remarks>
         private void AddNonICollectionRangeInternal(IEnumerable<T> items)

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -234,6 +234,18 @@ namespace Yuh.Collections
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void GrowExact(int length)
+        {
+            var newSegment = GC.AllocateUninitializedArray<T>(length);
+            _segments[_allocatedCount] = newSegment;
+
+            _allocatedCount++;
+            _currentSegment = newSegment.AsSpan();
+            _countInCurrentSegment = 0;
+            _nextSegmentLength <<= 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ResizeCurrentSegment(int length)
         {
             var newSegment = GC.AllocateUninitializedArray<T>(length);

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -100,16 +100,16 @@ namespace Yuh.Collections
         /// </remarks>
         /// <param name="items"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddNonICollectionRange(IEnumerable<T> items)
+        public void AddIEnumerableRange(IEnumerable<T> items)
         {
             ArgumentNullException.ThrowIfNull(items);
-            AddNonICollectionRangeInternal(items);
+            AddIEnumerableRangeInternal(items);
         }
 
         /// <remarks>
         /// This doesn't check if <paramref name="items"/> is null.
         /// </remarks>
-        private void AddNonICollectionRangeInternal(IEnumerable<T> items)
+        private void AddIEnumerableRangeInternal(IEnumerable<T> items)
         {
             var currentSegment = _currentSegment;
 

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -104,6 +104,27 @@ namespace Yuh.Collections
         }
 
         /// <summary>
+        /// This doesn't check if <paramref name="items"/> is null.
+        /// </remarks>
+        private void AddNonICollectionRangeInternal(IEnumerable<T> items)
+        {
+            var currentSegment = _currentSegment;
+
+            foreach (var item in items)
+            {
+                if (_countInCurrentSegment == currentSegment.Length)
+                {
+                    Grow();
+                    currentSegment = _currentSegment;
+                }
+
+                currentSegment[_countInCurrentSegment] = item;
+                _countInCurrentSegment++;
+                _count++;
+            }
+        }
+
+        /// <summary>
         /// Adds elements in the span to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="items">A span over elements to add.</param>

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -40,12 +40,6 @@ namespace Yuh.Collections
                 ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(firstSegmentLength), "The value is less than the minimum length of a segment, or greater than the maximum length of an array.");
             }
             _nextSegmentLength = firstSegmentLength;
-
-#if NET8_0_OR_GREATER
-            _segments = new();
-#else
-            _segments = GC.AllocateUninitializedArray<T[]>(27);
-#endif
         }
 
         /// <summary>

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -112,16 +112,20 @@ namespace Yuh.Collections
         private void AddIEnumerableRangeInternal(IEnumerable<T> items)
         {
             var currentSegment = _currentSegment;
+            ref T destRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(currentSegment), _countInCurrentSegment);
 
-            foreach (var item in items)
+            using var enumerator = items.GetEnumerator();
+            while (enumerator.MoveNext())
             {
                 if (_countInCurrentSegment == currentSegment.Length)
                 {
                     Grow();
                     currentSegment = _currentSegment;
+                    destRef = ref MemoryMarshal.GetReference(currentSegment);
                 }
 
-                currentSegment[_countInCurrentSegment] = item;
+                destRef = enumerator.Current;
+                destRef = ref Unsafe.Add(ref destRef, 1);
                 _countInCurrentSegment++;
                 _count++;
             }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -238,6 +238,11 @@ namespace Yuh.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GrowExact(int length)
         {
+            if (_allocatedCount == SegmentsCount)
+            {
+                ThrowHelpers.ThrowException(ThrowHelpers.M_CapacityReachedUpperLimit);
+            }
+
             var newSegment = GC.AllocateUninitializedArray<T>(length);
             _segments[_allocatedCount] = newSegment;
 

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -105,6 +105,7 @@ namespace Yuh.Collections
         /// Adds elements in a <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="items">An <see cref="IEnumerable{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddRange(IEnumerable<T> items)
         {
             ArgumentNullException.ThrowIfNull(items);

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -10,6 +10,8 @@ namespace Yuh.Collections
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     public ref struct CollectionBuilder<T>// : IDisposable
     {
+        public const int SegmentsCount = 27;
+
         public const int MinSegmentLength = 16;
 
         private int _allocatedCount = 0; // in the range [0, 27]


### PR DESCRIPTION
# Summary

It is able to get the number of elements in an `ICollection` from its property, so elements in an `ICollection{T}` can be added to a `CollectionBuilder{T}` more faster by using specialized method instead of using the existing method, `CollectionBuilder{T}.AddRange(IEnumerable{T})`.

# What I did

All changes are made to the `CollectionBuilder<T>` structure.

- Implement new methods.
  - public
    - `AddICollectionRange(ICollection<T>)`
    - `AddIEnumerableRange(IEnumerable<T>)`
  - private
    - `AddICollectionRangeInternal(ICollection<T>)`
    - `AddIEnumerableRange(IEnumerable<T>)`
    - `ExpandCurrentSegment(int)`
    - `Grow(int)`
    - `GrowExact(int)`
    - `ShrinkCurrentSegmentToFit()`
- Change implementation of some methods.
  - `Grow()`
    : call new private methods.
  - `AddRange(IEnumerable<T>)`
    : determine whether the given `IEnumerable<T>` is `ICollection<T>` or not, and call proper method.
- Refactor some methods to perform better.