### PR TITLE
Feat: extension class for CollectionBuilder{T}

### DIFF
--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -1,0 +1,17 @@
+﻿namespace Yuh.Collections.Tests
+{
+    public class CollectionBuilderExtensionsTest
+    {
+        [Fact]
+        public void ToStringTest()
+        {
+            CollectionBuilder<char> builder = new();
+            builder.AddRange("foo\n".AsSpan());
+            builder.AddRange("bar\n".AsSpan());
+            builder.AddRange("qux\n".AsSpan());
+            builder.AddRange("The quick brown fox jumps over the lazy dog.".AsSpan());
+
+            Assert.True(builder.ToStringBuilder().ToString() == "foo\nbar\nqux\nThe quick brown fox jumps over the lazy dog.");
+        }
+    }
+}

--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -3,7 +3,7 @@
     public class CollectionBuilderExtensionsTest
     {
         [Fact]
-        public void ToStringTest()
+        public void ToBasicStringTest()
         {
             CollectionBuilder<char> builder = new();
             builder.AddRange("foo\n".AsSpan());
@@ -11,7 +11,7 @@
             builder.AddRange("qux\n".AsSpan());
             builder.AddRange("The quick brown fox jumps over the lazy dog.".AsSpan());
 
-            Assert.True(builder.ToStringBuilder().ToString() == "foo\nbar\nqux\nThe quick brown fox jumps over the lazy dog.");
+            Assert.True(builder.ToBasicString() == "foo\nbar\nqux\nThe quick brown fox jumps over the lazy dog.");
         }
     }
 }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -349,29 +349,6 @@ namespace Yuh.Collections
             return array;
         }
 
-        /// <summary>
-        /// Creates an <see cref="List{T}"/> from the <see cref="CollectionBuilder{T}"/>.
-        /// </summary>
-        /// <returns>A <see cref="List{T}"/> which contains elements copied from the <see cref="CollectionBuilder{T}"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public readonly List<T> ToList()
-        {
-            if (_count == 0)
-            {
-                return [];
-            }
-
-#if NET8_0_OR_GREATER
-            var list = new List<T>(_count);
-            SysCollectionsMarshal.SetCount(list, _count);
-            CopyTo(SysCollectionsMarshal.AsSpan(list));
-#else
-            var list = Enumerable.Repeat(default(T)!, _count).ToList();
-            CopyTo(SysCollectionsMarshal.AsSpan(list));
-#endif
-            return list;
-        }
-
 #if NET8_0_OR_GREATER
         [InlineArray(SegmentsCount)]
         private struct SegmentsArray

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -271,7 +271,7 @@ namespace Yuh.Collections
         /// Returns the number of elements that can be contained in the <see cref="CollectionBuilder{T}"/> without allocate new internal array.
         /// </summary>
         /// <returns>The number of elements that can be contained in the <see cref="CollectionBuilder{T}"/> without allocating new internal array.</returns>
-        public int GetAllocatedCapacity()
+        public readonly int GetAllocatedCapacity()
         {
             int capacity = 0;
             for (int i = 0; i < _allocatedCount; i++)

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -267,6 +267,16 @@ namespace Yuh.Collections
             }
         }
 
+        public int GetAllocatedCapacity()
+        {
+            int capacity = 0;
+            for (int i = 0; i < _allocatedCount; i++)
+            {
+                capacity += _segments[i].Length;
+            }
+            return capacity;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Grow()
             => GrowExact(_nextSegmentLength);

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -267,6 +267,10 @@ namespace Yuh.Collections
             }
         }
 
+        /// <summary>
+        /// Returns the number of elements that can be contained in the <see cref="CollectionBuilder{T}"/> without allocate new internal array.
+        /// </summary>
+        /// <returns>The number of elements that can be contained in the <see cref="CollectionBuilder{T}"/> without allocating new internal array.</returns>
         public int GetAllocatedCapacity()
         {
             int capacity = 0;

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -56,7 +56,6 @@ namespace Yuh.Collections
 #if NET8_0_OR_GREATER
             SysCollectionsMarshal.SetCount(list, length);
             builder.CopyTo(SysCollectionsMarshal.AsSpan(list));
-            return list;
 #else
             if (length <= 1024 * 1024)
             {
@@ -69,9 +68,9 @@ namespace Yuh.Collections
             {
                 list.AddRange(builder.ToArray());
             }
+#endif
             return list;
         }
-#endif
 
         /// <summary>
         /// Creates a <see cref="string"/> from the <see cref="CollectionBuilder{T}"/>.

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -4,8 +4,17 @@ using System.Text;
 
 namespace Yuh.Collections
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="CollectionBuilder{T}"/> structure.
+    /// </summary>
     public static class CollectionBuilderExtensions
     {
+        /// <summary>
+        /// Creates a new instance of the <see cref="Deque{T}"/> class that contains elements copied from the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of elements of the collection.</typeparam>
+        /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements are copied to the new <see cref="Deque{T}"/>.</param>
+        /// <returns>A new <see cref="Deque{T}"/> whose elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static Deque<T> ToDeque<T>(in this CollectionBuilder<T> builder)
         {
             T[] values = new T[builder.GetAllocatedCapacity()];
@@ -13,6 +22,12 @@ namespace Yuh.Collections
             return new(values, 0, builder.Count);
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="DoubleEndedList{T}"/> class that contains elements copied from the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of elements of the collection.</typeparam>
+        /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements are copied to the new <see cref="DoubleEndedList{T}"/>.</param>
+        /// <returns>A new <see cref="DoubleEndedList{T}"/> whose elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static Deque<T> ToDoubleEndedList<T>(in this CollectionBuilder<T> builder)
         {
             int capacity = builder.GetAllocatedCapacity();
@@ -26,6 +41,11 @@ namespace Yuh.Collections
             return new(values, head, length);
         }
 
+        /// <summary>
+        /// Creates a new <see cref="string"/> from the <see cref="CollectionBuilder{T}"/> the type of which is <see cref="char"/>.
+        /// </summary>
+        /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements (characters) are copied to the new <see cref="string"/>.</param>
+        /// <returns>A new <see cref="string"/> whose characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static string ToString(in this CollectionBuilder<char> builder)
         {
             int length = builder.Count;
@@ -47,6 +67,11 @@ namespace Yuh.Collections
             }
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="StringBuilder"/> class that contains characters copied from the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements (characters) are copied to the new <see cref="StringBuilder"/>.</param>
+        /// <returns>A new <see cref="StringBuilder"/> whose characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static StringBuilder ToStringBuilder(in this CollectionBuilder<char> builder)
         {
             int length = builder.Count;

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace Yuh.Collections
                 builder.CopyTo(chars);
                 return new(chars);
             }
-            else
+            else if (length <= 1024 * 1024)
             {
                 var charsArray = ArrayPool<char>.Shared.Rent(length);
                 var chars = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(charsArray), length);
@@ -95,6 +95,10 @@ namespace Yuh.Collections
 
                 ArrayPool<char>.Shared.Return(charsArray);
                 return s;
+            }
+            else
+            {
+                return new(builder.ToArray());
             }
         }
 
@@ -113,7 +117,7 @@ namespace Yuh.Collections
                 builder.CopyTo(chars);
                 return sb.Append(chars);
             }
-            else
+            else if (length <= 1024 * 1024)
             {
                 var charsArray = ArrayPool<char>.Shared.Rent(length);
                 var chars = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(charsArray), length);
@@ -122,6 +126,10 @@ namespace Yuh.Collections
 
                 ArrayPool<char>.Shared.Return(charsArray);
                 return sb;
+            }
+            else
+            {
+                return sb.Append(builder.ToArray());
             }
         }
     }

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -6,5 +6,47 @@ namespace Yuh.Collections
 {
     public static class CollectionBuilderExtensions
     {
+        public static string ToString(in this CollectionBuilder<char> builder)
+        {
+            int length = builder.Count;
+            if (length <= 1024)
+            {
+                Span<char> chars = stackalloc char[length];
+                builder.CopyTo(chars);
+                return new(chars);
+            }
+            else
+            {
+                var charsArray = ArrayPool<char>.Shared.Rent(length);
+                var chars = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(charsArray), length);
+                builder.CopyTo(chars);
+                string s = new(chars);
+
+                ArrayPool<char>.Shared.Return(charsArray);
+                return s;
+            }
+        }
+
+        public static StringBuilder ToStringBuilder(in this CollectionBuilder<char> builder)
+        {
+            int length = builder.Count;
+            StringBuilder sb = new(length);
+            if (length <= 1024)
+            {
+                Span<char> chars = stackalloc char[length];
+                builder.CopyTo(chars);
+                return sb.Append(chars);
+            }
+            else
+            {
+                var charsArray = ArrayPool<char>.Shared.Rent(length);
+                var chars = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(charsArray), length);
+                builder.CopyTo(chars);
+                sb.Append(chars);
+
+                ArrayPool<char>.Shared.Return(charsArray);
+                return sb;
+            }
+        }
     }
 }

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Yuh.Collections
         /// <typeparam name="T">The type of elements of the collection.</typeparam>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements are copied to the new <see cref="DoubleEndedList{T}"/>.</param>
         /// <returns>A new <see cref="DoubleEndedList{T}"/> whose elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
-        public static Deque<T> ToDoubleEndedList<T>(in this CollectionBuilder<T> builder)
+        public static DoubleEndedList<T> ToDoubleEndedList<T>(in this CollectionBuilder<T> builder)
         {
             int capacity = builder.GetAllocatedCapacity();
             int length = builder.Count;

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Yuh.Collections
+{
+    public static class CollectionBuilderExtensions
+    {
+    }
+}

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace Yuh.Collections
         /// </summary>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements (characters) are copied to the new <see cref="string"/>.</param>
         /// <returns>A new <see cref="string"/> whose characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
-        public static string ToString(in this CollectionBuilder<char> builder)
+        public static string ToBasicString(in this CollectionBuilder<char> builder)
         {
             int length = builder.Count;
             if (length <= 1024)

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -10,11 +10,11 @@ namespace Yuh.Collections
     public static class CollectionBuilderExtensions
     {
         /// <summary>
-        /// Creates a new instance of the <see cref="Deque{T}"/> class that contains elements copied from the <see cref="CollectionBuilder{T}"/>.
+        /// Creates a <see cref="Deque{T}"/> from the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements of the collection.</typeparam>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements are copied to the new <see cref="Deque{T}"/>.</param>
-        /// <returns>A new <see cref="Deque{T}"/> whose elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
+        /// <returns>A <see cref="Deque{T}"/> which contains elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static Deque<T> ToDeque<T>(in this CollectionBuilder<T> builder)
         {
             T[] values = new T[builder.GetAllocatedCapacity()];
@@ -23,11 +23,11 @@ namespace Yuh.Collections
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="DoubleEndedList{T}"/> class that contains elements copied from the <see cref="CollectionBuilder{T}"/>.
+        /// Creates <see cref="DoubleEndedList{T}"/> from the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements of the collection.</typeparam>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements are copied to the new <see cref="DoubleEndedList{T}"/>.</param>
-        /// <returns>A new <see cref="DoubleEndedList{T}"/> whose elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
+        /// <returns>A <see cref="DoubleEndedList{T}"/> which contains elements are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static DoubleEndedList<T> ToDoubleEndedList<T>(in this CollectionBuilder<T> builder)
         {
             int capacity = builder.GetAllocatedCapacity();
@@ -42,10 +42,10 @@ namespace Yuh.Collections
         }
 
         /// <summary>
-        /// Creates a new <see cref="string"/> from the <see cref="CollectionBuilder{T}"/> the type of which is <see cref="char"/>.
+        /// Creates a <see cref="string"/> from the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements (characters) are copied to the new <see cref="string"/>.</param>
-        /// <returns>A new <see cref="string"/> whose characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
+        /// <returns>A <see cref="string"/> which contains characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static string ToBasicString(in this CollectionBuilder<char> builder)
         {
             int length = builder.Count;
@@ -68,10 +68,10 @@ namespace Yuh.Collections
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="StringBuilder"/> class that contains characters copied from the <see cref="CollectionBuilder{T}"/>.
+        /// Creates <see cref="StringBuilder"/> from the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements (characters) are copied to the new <see cref="StringBuilder"/>.</param>
-        /// <returns>A new <see cref="StringBuilder"/> whose characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
+        /// <returns>A <see cref="StringBuilder"/> which contains characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
         public static StringBuilder ToStringBuilder(in this CollectionBuilder<char> builder)
         {
             int length = builder.Count;

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -6,6 +6,26 @@ namespace Yuh.Collections
 {
     public static class CollectionBuilderExtensions
     {
+        public static Deque<T> ToDeque<T>(in this CollectionBuilder<T> builder)
+        {
+            T[] values = new T[builder.GetAllocatedCapacity()];
+            builder.CopyTo(values.AsSpan());
+            return new(values, 0, builder.Count);
+        }
+
+        public static Deque<T> ToDoubleEndedList<T>(in this CollectionBuilder<T> builder)
+        {
+            int capacity = builder.GetAllocatedCapacity();
+            int length = builder.Count;
+            int head = (capacity - length) >> 1;
+            T[] values = new T[capacity];
+
+            builder.CopyTo(
+                MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(values), head)
+            );
+            return new(values, head, length);
+        }
+
         public static string ToString(in this CollectionBuilder<char> builder)
         {
             int length = builder.Count;

--- a/src/Yuh.Collections/Deque.cs
+++ b/src/Yuh.Collections/Deque.cs
@@ -249,6 +249,14 @@ namespace Yuh.Collections
             _head = 0;
         }
 
+        internal Deque(T[] innerArray, int head, int count)
+        {
+            _capacity = innerArray.Length;
+            _count = count;
+            _head = head;
+            _items = innerArray;
+        }
+
         void ICollection<T>.Add(T item)
         {
             PushBack(item);

--- a/src/Yuh.Collections/DoubleEndedList.cs
+++ b/src/Yuh.Collections/DoubleEndedList.cs
@@ -187,6 +187,13 @@ namespace Yuh.Collections
             _version++;
         }
 
+        internal DoubleEndedList(T[] innerArray, int head, int count)
+        {
+            _count = count;
+            _head = head;
+            _items = innerArray;
+        }
+
         int IList.Add(object? value)
         {
             if (value is T tValue)


### PR DESCRIPTION
# Summary

Implement extension class for `CollectionBuilder{T}` that provides methods to create collections from a `CollectionBuilder{T}`.

# What I did

All changes are made to `CollectionBuilderExtension` class and `CollectionBuilder<T>` structure.

- Implement new methods to `CollectionBuilderExtension` class.
  - public
    - `ToDeque<T>(CollectionBuilder<T>)`
    - `ToDoubleEndedList<T>(CollectionBuilder<T>)`
    - `ToList<T>(CollectionBuilder<T>)`
    - `ToBasicString(CollectionBuilder<char>)`
    - `ToStringBuilder(CollectionBuilder<char>)`
- Implement new constructors.
  - internal
    - `Deque<T>.ctor(T[], int, int)`
    - `DoubleEndedList<T>.ctor(T[], int, int)`
- Remove existing method.
  - `CollectionBuilder<T>.ToList()`
    : moved to  `CollectionBuilderExtensions.ToList<T>(CollectionBuilder<T>)`

## Related Issues

- Resolve #11
