### PR TITLE
Refactor: use ArrayPool{T} in collection-builder

### DIFF
--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -6,10 +6,10 @@
         public void ToBasicStringTest()
         {
             CollectionBuilder<char> builder = new();
-            builder.AddRange("foo\n".AsSpan());
-            builder.AddRange("bar\n".AsSpan());
-            builder.AddRange("qux\n".AsSpan());
-            builder.AddRange("The quick brown fox jumps over the lazy dog.".AsSpan());
+            builder.AppendRange("foo\n".AsSpan());
+            builder.AppendRange("bar\n".AsSpan());
+            builder.AppendRange("qux\n".AsSpan());
+            builder.AppendRange("The quick brown fox jumps over the lazy dog.".AsSpan());
 
             Assert.True(builder.ToBasicString() == "foo\nbar\nqux\nThe quick brown fox jumps over the lazy dog.");
         }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -79,7 +79,7 @@ namespace Yuh.Collections
         /// </summary>
         /// <param name="item">An object to add.</param>
         /// <exception cref="Exception">The <see cref="CollectionBuilder{T}"/> is already full.</exception>
-        public void Add(T item)
+        public void Append(T item)
         {
             if (_count == Array.MaxLength)
             {
@@ -97,13 +97,13 @@ namespace Yuh.Collections
         /// Adds elements in an <see cref="ICollection{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>
         /// </summary>
         /// <param name="items">An <see cref="ICollection{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
-        public void AddICollectionRange(ICollection<T> items)
+        public void AppendICollectionRange(ICollection<T> items)
         {
             ArgumentNullException.ThrowIfNull(items);
-            AddICollectionRangeInternal(items);
+            AppendICollectionRangeInternal(items);
         }
 
-        private void AddICollectionRangeInternal(ICollection<T> items)
+        private void AppendICollectionRangeInternal(ICollection<T> items)
         {
             int itemsLength = items.Count;
             if (itemsLength == 0)
@@ -112,7 +112,7 @@ namespace Yuh.Collections
             }
             else if (itemsLength == 1)
             {
-                Add(items.First());
+                Append(items.First());
                 return;
             }
 
@@ -153,17 +153,17 @@ namespace Yuh.Collections
         /// Adds elements in an <see cref="IEnumerable{T}"/> to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <param name="items">An <see cref="IEnumerable{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
-        public void AddRange(IEnumerable<T> items)
+        public void AppendRange(IEnumerable<T> items)
         {
             ArgumentNullException.ThrowIfNull(items);
 
             if (items is ICollection<T> collection)
             {
-                AddICollectionRangeInternal(collection);
+                AppendICollectionRangeInternal(collection);
             }
             else
             {
-                AddIEnumerableRangeInternal(items);
+                AppendIEnumerableRangeInternal(items);
             }
         }
 
@@ -174,16 +174,16 @@ namespace Yuh.Collections
         /// This implementation assumes that <paramref name="items"/> is NOT <see cref="ICollection{T}"/> and thus doesn't check if it is.
         /// </remarks>
         /// <param name="items">An <see cref="IEnumerable{T}"/> whose elements are copied to the <see cref="CollectionBuilder{T}"/>.</param>
-        public void AddIEnumerableRange(IEnumerable<T> items)
+        public void AppendIEnumerableRange(IEnumerable<T> items)
         {
             ArgumentNullException.ThrowIfNull(items);
-            AddIEnumerableRangeInternal(items);
+            AppendIEnumerableRangeInternal(items);
         }
 
         /// <remarks>
         /// This doesn't check if <paramref name="items"/> is null.
         /// </remarks>
-        private void AddIEnumerableRangeInternal(IEnumerable<T> items)
+        private void AppendIEnumerableRangeInternal(IEnumerable<T> items)
         {
             int countInCurrentSegment = _countInCurrentSegment;
             var currentSegment = _currentSegment;
@@ -216,7 +216,7 @@ namespace Yuh.Collections
         /// </summary>
         /// <param name="items">A span over elements to add.</param>
         /// <exception cref="ArgumentException">The <see cref="CollectionBuilder{T}"/> doesn't have enough space to accommodate elements contained in <paramref name="items"/>.</exception>
-        public void AddRange(scoped ReadOnlySpan<T> items)
+        public void AppendRange(scoped ReadOnlySpan<T> items)
         {
             if (items.Length == 0)
             {
@@ -224,7 +224,7 @@ namespace Yuh.Collections
             }
             else if (items.Length == 1)
             {
-                Add(items[0]);
+                Append(items[0]);
                 return;
             }
             if (items.Length > Array.MaxLength - _count) // use this way to avoid overflow

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -447,6 +447,11 @@ namespace Yuh.Collections
             }
         }
 
+        /// <summary>
+        /// Removes specified number of elements from the end of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <param name="length">The number of elements to remove from the <see cref="CollectionBuilder{T}"/>.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is negative or greater than <see cref="Count"/>.</exception>
         public void RemoveRange(int length)
         {
             if (length == 0)
@@ -472,6 +477,11 @@ namespace Yuh.Collections
             }
         }
 
+        /// <summary>
+        /// Reserves the specified length of memory region from the back of the <see cref="CollectionBuilder{T}"/> and returns the span over the region.
+        /// </summary>
+        /// <param name="length">The number of elements that the reserved memory region can exactly accommodate.</param>
+        /// <returns>The span over the reserved memory region.</returns>
         public Span<T> ReserveRange(int length)
         {
             if (Array.MaxLength - _count < (uint)length)

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -267,6 +267,21 @@ namespace Yuh.Collections
             }
         }
 
+        [method: MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ExpandCurrentSegment(int length)
+        {
+            var newSegment = GC.AllocateUninitializedArray<T>(length);
+            var newSegmentSpan = newSegment.AsSpan();
+
+            var src = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(_currentSegment), _countInCurrentSegment);
+            src.CopyTo(newSegmentSpan);
+
+            _segments[_segmentsCount - 1] = newSegment;
+            _currentSegment = newSegmentSpan;
+
+            CollectionHelpers.ClearIfReferenceOrContainsReferences(src);
+        }
+
         /// <summary>
         /// Returns the number of elements that can be contained in the <see cref="CollectionBuilder{T}"/> without allocate new internal array.
         /// </summary>
@@ -318,21 +333,6 @@ namespace Yuh.Collections
             _currentSegment = newSegment.AsSpan();
             _countInCurrentSegment = 0;
             _nextSegmentLength <<= 1;
-        }
-
-        [method: MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ExpandCurrentSegment(int length)
-        {
-            var newSegment = GC.AllocateUninitializedArray<T>(length);
-            var newSegmentSpan = newSegment.AsSpan();
-
-            var src = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(_currentSegment), _countInCurrentSegment);
-            src.CopyTo(newSegmentSpan);
-
-            _segments[_segmentsCount - 1] = newSegment;
-            _currentSegment = newSegmentSpan;
-
-            CollectionHelpers.ClearIfReferenceOrContainsReferences(src);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -34,7 +34,7 @@ namespace Yuh.Collections
     /// Represents a temporary collection that is used to build new collections.
     /// </summary>
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
-    public unsafe ref struct CollectionBuilder<T>// : IDisposable
+    public unsafe ref struct CollectionBuilder<T> // : IDisposable
     {
         private int _count = 0;
         private int _countInCurrentSegment = 0;
@@ -521,7 +521,7 @@ namespace Yuh.Collections
 
         private static void ReturnIfArrayIsFromArrayPool(T[] array)
         {
-            if((uint)(array.Length - CollectionBuilder.MinArrayLengthFromArrayPool) <= (CollectionBuilder.MaxArrayLengthFromArrayPool - CollectionBuilder.MinArrayLengthFromArrayPool))
+            if ((uint)(array.Length - CollectionBuilder.MinArrayLengthFromArrayPool) <= (CollectionBuilder.MaxArrayLengthFromArrayPool - CollectionBuilder.MinArrayLengthFromArrayPool))
             {
                 ArrayPool<T>.Shared.Return(array);
             }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -281,14 +281,28 @@ namespace Yuh.Collections
             return capacity;
         }
 
+        /// <summary>
+        /// Allocate new buffer than can accommodate at least <see cref="_nextSegmentLength"/> elements.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Grow()
             => GrowExact(_nextSegmentLength);
 
+        /// <summary>
+        /// Allocate new buffer than can accommodate at least specified number of elements.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="neededLength"/> is greater than <see cref="_nextSegmentLength"/>, this method allocate new buffer that can accommodate <paramref name="neededLength"/> elements; otherwise, <see cref="_nextSegmentLength"/> elements.
+        /// </remarks>
+        /// <param name="neededLength"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Grow(int neededLength)
             => GrowExact(Math.Max(neededLength, _nextSegmentLength));
 
+        /// <summary>
+        /// Allocate new buffer that can accommodate at least specified number of elements.
+        /// </summary>
+        /// <param name="length"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GrowExact(int length)
         {

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -18,8 +18,8 @@ namespace Yuh.Collections
         public const int MinSegmentLength = 16;
 
         private int _count = 0;
-        private Span<T> _currentSegment = [];
         private int _countInCurrentSegment = 0;
+        private Span<T> _currentSegment = [];
         private int _nextSegmentLength = MinSegmentLength;
         private int _segmentsCount = 0; // in the range [0, 27]
 

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -12,6 +12,14 @@ namespace Yuh.Collections
     {
         private const int MinInitialReserveLength = 32;
 
+        /// <summary>
+        /// Appends a string to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <param name="builder">The collection builder to add <paramref name="s"/> to.</param>
+        /// <param name="s">
+        ///     A string to add.
+        ///     The value can be null or empty string.
+        /// </param>
         public static void AppendLiteral(ref this CollectionBuilder<char> builder, string? s)
         {
             if (string.IsNullOrEmpty(s))
@@ -28,6 +36,15 @@ namespace Yuh.Collections
             }
         }
 
+        /// <summary>
+        /// Appends the string expression of the value to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="builder">The collection builder to add a string to.</param>
+        /// <param name="value">The value the string expression of which is added to <paramref name="builder"/>.</param>
+        /// <param name="estimatedStringLength">The estimated length of a string to add.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for the destination collection.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for the destination collection.</param>
         public static void AppendFormatted<T>(ref this CollectionBuilder<char> builder, T value, int estimatedStringLength = MinInitialReserveLength, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             if (value is ISpanFormattable valueSpanFormattable)


### PR DESCRIPTION
# What I did

- Change to use `ArrayPool<T>` in `CollectionBuilder<T>` structure.
- Rename some public methods in `CollectionBuilder<T>` structure.
  - `Add` -> `Append`
  - `AddICollectionRange` -> `AppendICollectionRange`
  - `AddIEnumerableRange` -> `AppendIEnumerableRange`
  - `AddRange` -> `AppendRange` 
- New public methods in `CollectionBuilder<T>` structure.
  - `RemoveRange(int)`
  - `ReserveRange(int)`
- New public methods in `CollectionBuilderExtensions` class.
  - `AppendLiteral(ref this CollectionBuilder<char>, string?)`
  - `AppendFormatted<T>(ref this CollectionBuilder<char>, T, [int], [ReadOnlySpan<char>], [IFormatProvider?])`