### PR TITLE
Feat: Extension methods for CollectionBuilder{byte} structure

### DIFF
--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -83,6 +83,29 @@ namespace Yuh.Collections.Tests
         }
 
         [Theory]
+        [ClassData(typeof(StringArrayData))]
+        public void AppendLiteralToUtf8StringBuilderTest(string[] data)
+        {
+            CollectionBuilder<byte> builder = [];
+            DefaultInterpolatedStringHandler handler = new(data.Select(x => x.Length).Sum(), 0);
+
+            try
+            {
+                foreach (var s in data)
+                {
+                    builder.AppendLiteral(s);
+                    handler.AppendLiteral(s);
+                }
+
+                Assert.Equal(handler.ToStringAndClear(), Encoding.UTF8.GetString(builder.ToArray()));
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
+        [Theory]
         [ClassData(typeof(SegmentedIntArrayData))]
         public void ToDoubleEndedListTest(int[][] items)
         {
@@ -108,6 +131,29 @@ namespace Yuh.Collections.Tests
             }
 
             Assert.Equal(items.Flatten().ToList(), builder.ToList());
+        }
+
+        [Theory]
+        [ClassData(typeof(StringArrayData))]
+        public void ToSystemStringFromUtf8StringBuilder(string[] data)
+        {
+            CollectionBuilder<byte> builder = [];
+            DefaultInterpolatedStringHandler handler = new(data.Select(x => x.Length).Sum(), 0);
+
+            try
+            {
+                foreach (var s in data)
+                {
+                    builder.AppendLiteral(s);
+                    handler.AppendLiteral(s);
+                }
+
+                Assert.Equal(handler.ToStringAndClear(), builder.ToSystemString());
+            }
+            finally
+            {
+                builder.Dispose();
+            }
         }
 
         [Theory]

--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -28,7 +28,7 @@ namespace Yuh.Collections.Tests
                     handler.AppendFormatted(f);
                 }
 
-                Assert.Equal(handler.ToStringAndClear(), builder.ToBasicString());
+                Assert.Equal(handler.ToStringAndClear(), builder.ToSystemString());
             }
             finally
             {
@@ -112,7 +112,7 @@ namespace Yuh.Collections.Tests
 
         [Theory]
         [ClassData(typeof(StringArrayData))]
-        public void ToBasicStringTest(string[] items)
+        public void ToSystemStringTest(string[] items)
         {
             using CollectionBuilder<char> builder = new();
             DefaultInterpolatedStringHandler handler = new(0, items.Length);
@@ -123,7 +123,7 @@ namespace Yuh.Collections.Tests
                 handler.AppendFormatted(str);
             }
 
-            Assert.Equal(handler.ToStringAndClear(), builder.ToBasicString());
+            Assert.Equal(handler.ToStringAndClear(), builder.ToSystemString());
         }
 
         [Theory]
@@ -137,7 +137,7 @@ namespace Yuh.Collections.Tests
                 builder.AppendRange(str.AsSpan());
             }
 
-            Assert.Equal(builder.ToBasicString(), builder.ToStringBuilder().ToString());
+            Assert.Equal(builder.ToSystemString(), builder.ToStringBuilder().ToString());
         }
     }
 }

--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Text;
 using Yuh.Collections.Tests.DataProviders;
 using Yuh.Collections.Tests.Helpers;
 
@@ -28,6 +29,52 @@ namespace Yuh.Collections.Tests
                 }
 
                 Assert.Equal(handler.ToStringAndClear(), builder.ToBasicString());
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FormattedData))]
+        public void AppendUtf8FormattedTest(IFormattable[] items)
+        {
+            CollectionBuilder<byte> builder = [];
+            DefaultInterpolatedStringHandler handler = new(0, items.Length);
+
+            try
+            {
+                foreach (var f in items)
+                {
+                    builder.AppendUtf8Formatted(f);
+                    handler.AppendFormatted(f);
+                }
+
+                Assert.Equal(Encoding.UTF8.GetBytes(handler.ToStringAndClear()), builder.ToArray());
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(StringArrayData))]
+        public void AppendUtf8LiteralTest(string[] data)
+        {
+            CollectionBuilder<byte> builder = [];
+            DefaultInterpolatedStringHandler handler = new(data.Select(x => x.Length).Sum(), 0);
+
+            try
+            {
+                foreach (var s in data)
+                {
+                    builder.AppendLiteral(s);
+                    handler.AppendLiteral(s);
+                }
+
+                Assert.Equal(Encoding.UTF8.GetBytes(handler.ToStringAndClear()), builder.ToArray());
             }
             finally
             {

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -938,18 +938,18 @@ namespace Yuh.Collections
         {
             private readonly int _countInFinalSegment;
             private ReadOnlyMemory<T> _currentMemory = ReadOnlyMemory<T>.Empty;
-            private ReadOnlySpan<T> _currentSegment = [];
+            private ReadOnlySpan<T> _currentSpan = [];
             private int _index = -1;
             private ReadOnlySpan<T[]> _segments;
 
             public readonly ReadOnlyMemory<T> CurrentMemory => _currentMemory;
 
-            public readonly ReadOnlySpan<T> CurrentSpan => _currentSegment;
+            public readonly ReadOnlySpan<T> CurrentSpan => _currentSpan;
 
             readonly object? IEnumerator.Current => throw new NotSupportedException();
             readonly ReadOnlyMemory<T> IEnumerator<ReadOnlyMemory<T>>.Current => _currentMemory;
 #if NET9_0_OR_GREATER
-            readonly ReadOnlySpan<T> IEnumerator<ReadOnlySpan<T>>.Current => _currentSegment;
+            readonly ReadOnlySpan<T> IEnumerator<ReadOnlySpan<T>>.Current => _currentSpan;
 #endif
 
             internal SegmentEnumerator(ReadOnlySpan<T[]> segments, int countInFinalSegment) : this()
@@ -960,7 +960,7 @@ namespace Yuh.Collections
 
             public void Dispose()
             {
-                _currentSegment = [];
+                _currentSpan = [];
                 _segments = [];
             }
 
@@ -971,22 +971,22 @@ namespace Yuh.Collections
 
                 if (index < segmentCount - 1)
                 {
-                    _currentSegment = _segments[index].AsSpan();
+                    _currentSpan = _segments[index].AsSpan();
                     return true;
                 }
                 else if (index == segmentCount - 1)
                 {
-                    _currentSegment = _segments[index].AsSpan()[.._countInFinalSegment];
+                    _currentSpan = _segments[index].AsSpan()[.._countInFinalSegment];
                     return true;
                 }
 
-                _currentSegment = [];
+                _currentSpan = [];
                 return false;
             }
 
             public void Reset()
             {
-                _currentSegment = [];
+                _currentSpan = [];
                 _index = -1;
             }
         }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -582,11 +582,6 @@ namespace Yuh.Collections
             return new SegmentEnumerator(AllocatedSegments, _countInCurrentSegment);
         }
 
-        public readonly SegmentMemoryEnumerator GetSegmentMemoryEnumerator()
-        {
-            return new SegmentMemoryEnumerator(AllocatedSegments, _countInCurrentSegment);
-        }
-
         /// <summary>
         /// Allocates new buffer than can accommodate at least <see cref="_nextSegmentLength"/> elements.
         /// </summary>
@@ -1019,56 +1014,6 @@ namespace Yuh.Collections
             {
                 _currentMemory = ReadOnlyMemory<T>.Empty;
                 _currentSpan = [];
-                _index = -1;
-            }
-        }
-
-        public ref struct SegmentMemoryEnumerator : IEnumerator<ReadOnlyMemory<T>>
-        {
-            private readonly int _countInFinalSegment;
-            private ReadOnlyMemory<T> _currentSegment = ReadOnlyMemory<T>.Empty;
-            private int _index = -1;
-            private ReadOnlySpan<T[]> _segments;
-
-            public readonly ReadOnlyMemory<T> Current => _currentSegment;
-
-            readonly object? IEnumerator.Current => Current;
-
-            internal SegmentMemoryEnumerator(ReadOnlySpan<T[]> segments, int countInFinalSegment) : this()
-            {
-                _segments = segments;
-                _countInFinalSegment = countInFinalSegment;
-            }
-
-            public void Dispose()
-            {
-                _currentSegment = ReadOnlyMemory<T>.Empty;
-                _segments = [];
-            }
-
-            public bool MoveNext()
-            {
-                var segmentCount = _segments.Length;
-                var index = ++_index;
-
-                if (index < segmentCount - 1)
-                {
-                    _currentSegment = _segments[index].AsMemory();
-                    return true;
-                }
-                else if (index == segmentCount - 1)
-                {
-                    _currentSegment = new ReadOnlyMemory<T>(_segments[index], 0, _countInFinalSegment);
-                    return true;
-                }
-
-                _currentSegment = ReadOnlyMemory<T>.Empty;
-                return false;
-            }
-
-            public void Reset()
-            {
-                _currentSegment = ReadOnlyMemory<T>.Empty;
                 _index = -1;
             }
         }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -46,7 +46,7 @@ namespace Yuh.Collections
                 if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 {
                     ((Span<T>)Array).Clear();
-    }
+                }
 #else
                 ArrayPool<T>.Shared.Return(Array, RuntimeHelpers.IsReferenceOrContainsReferences<T>());
                 Array = [];
@@ -570,6 +570,16 @@ namespace Yuh.Collections
         readonly IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerableForIteration().GetEnumerator();
 
         readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerableForIteration().GetEnumerator();
+
+        public readonly SegmentEnumerator GetSegmentEnumerator()
+        {
+            return new SegmentEnumerator(AllocatedSegments, _countInCurrentSegment);
+        }
+
+        public readonly SegmentMemoryEnumerator GetSegmentMemoryEnumerator()
+        {
+            return new SegmentMemoryEnumerator(AllocatedSegments, _countInCurrentSegment);
+        }
 
         /// <summary>
         /// Allocates new buffer than can accommodate at least <see cref="_nextSegmentLength"/> elements.

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -931,18 +931,25 @@ namespace Yuh.Collections
 
         public ref struct SegmentEnumerator
 #if NET9_0_OR_GREATER
-            : IEnumerator<ReadOnlySpan<T>>
+            : IEnumerator<ReadOnlyMemory<T>>, IEnumerator<ReadOnlySpan<T>>
+#else
+            : IEnumerator<ReadOnlyMemory<T>>
 #endif
         {
             private readonly int _countInFinalSegment;
+            private ReadOnlyMemory<T> _currentMemory = ReadOnlyMemory<T>.Empty;
             private ReadOnlySpan<T> _currentSegment = [];
             private int _index = -1;
             private ReadOnlySpan<T[]> _segments;
 
-            public readonly ReadOnlySpan<T> Current => _currentSegment;
+            public readonly ReadOnlyMemory<T> CurrentMemory => _currentMemory;
 
-#if NET9_0_OR_GREATER
+            public readonly ReadOnlySpan<T> CurrentSpan => _currentSegment;
+
             readonly object? IEnumerator.Current => throw new NotSupportedException();
+            readonly ReadOnlyMemory<T> IEnumerator<ReadOnlyMemory<T>>.Current => _currentMemory;
+#if NET9_0_OR_GREATER
+            readonly ReadOnlySpan<T> IEnumerator<ReadOnlySpan<T>>.Current => _currentSegment;
 #endif
 
             internal SegmentEnumerator(ReadOnlySpan<T[]> segments, int countInFinalSegment) : this()

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -59,6 +59,7 @@ namespace Yuh.Collections
     /// Represents a temporary collection that is used to build new collections.
     /// </summary>
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    [DebuggerDisplay("Count = {_count}, SegmentsCount = {_segmentCount}")]
     public unsafe ref struct CollectionBuilder<T> : IDisposable, IEnumerable<T>
     {
         /// <summary>

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -960,6 +960,7 @@ namespace Yuh.Collections
 
             public void Dispose()
             {
+                _currentMemory = ReadOnlyMemory<T>.Empty;
                 _currentSpan = [];
                 _segments = [];
             }
@@ -971,21 +972,28 @@ namespace Yuh.Collections
 
                 if (index < segmentCount - 1)
                 {
-                    _currentSpan = _segments[index].AsSpan();
+                    var seg = _segments[index];
+                    _currentMemory = seg.AsMemory();
+                    _currentSpan = seg.AsSpan();
                     return true;
                 }
                 else if (index == segmentCount - 1)
                 {
-                    _currentSpan = _segments[index].AsSpan()[.._countInFinalSegment];
+                    var seg = _segments[index];
+                    var countInFinalSegment = _countInFinalSegment;
+                    _currentMemory = new ReadOnlyMemory<T>(seg, 0, countInFinalSegment);
+                    _currentSpan = new ReadOnlySpan<T>(seg, 0, countInFinalSegment);
                     return true;
                 }
 
+                _currentMemory = ReadOnlyMemory<T>.Empty;
                 _currentSpan = [];
                 return false;
             }
 
             public void Reset()
             {
+                _currentMemory = ReadOnlyMemory<T>.Empty;
                 _currentSpan = [];
                 _index = -1;
             }

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -571,6 +571,12 @@ namespace Yuh.Collections
 
         readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerableForIteration().GetEnumerator();
 
+        /// <summary>
+        /// Returns an enumerator that enumerates segments in the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="SegmentEnumerator"/> that can be used to enumerate segments in the <see cref="CollectionBuilder{T}"/>.
+        /// </returns>
         public readonly SegmentEnumerator GetSegmentEnumerator()
         {
             return new SegmentEnumerator(AllocatedSegments, _countInCurrentSegment);
@@ -929,6 +935,9 @@ namespace Yuh.Collections
 #endif
         }
 
+        /// <summary>
+        /// An enumerator that can be used to enumerate segments of a <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
         public ref struct SegmentEnumerator
 #if NET9_0_OR_GREATER
             : IEnumerator<ReadOnlyMemory<T>>, IEnumerator<ReadOnlySpan<T>>
@@ -942,8 +951,20 @@ namespace Yuh.Collections
             private int _index = -1;
             private ReadOnlySpan<T[]> _segments;
 
+            /// <summary>
+            /// Gets the non <see langword="ref struct"/> span over the segment in the <see cref="CollectionBuilder{T}"/> at the current position of the enumerator.
+            /// </summary>
+            /// <returns>
+            /// The non <see langword="ref struct"/> span over the segment in the <see cref="CollectionBuilder{T}"/> at the current position of the enumerator.
+            /// </returns>
             public readonly ReadOnlyMemory<T> CurrentMemory => _currentMemory;
 
+            /// <summary>
+            /// Gets the span over the segment in the <see cref="CollectionBuilder{T}"/> at the current position of the enumerator.
+            /// </summary>
+            /// <returns>
+            /// The span over the segment in the <see cref="CollectionBuilder{T}"/> at the current position of the enumerator.
+            /// </returns>
             public readonly ReadOnlySpan<T> CurrentSpan => _currentSpan;
 
             readonly object? IEnumerator.Current => throw new NotSupportedException();
@@ -958,6 +979,7 @@ namespace Yuh.Collections
                 _segments = segments;
             }
 
+            /// <inheritdoc/>
             public void Dispose()
             {
                 _currentMemory = ReadOnlyMemory<T>.Empty;
@@ -965,6 +987,7 @@ namespace Yuh.Collections
                 _segments = [];
             }
 
+            /// <inheritdoc/>
             public bool MoveNext()
             {
                 var segmentCount = _segments.Length;
@@ -991,6 +1014,7 @@ namespace Yuh.Collections
                 return false;
             }
 
+            /// <inheritdoc/>
             public void Reset()
             {
                 _currentMemory = ReadOnlyMemory<T>.Empty;

--- a/src/Yuh.Collections/CollectionBuilder.cs
+++ b/src/Yuh.Collections/CollectionBuilder.cs
@@ -830,7 +830,7 @@ namespace Yuh.Collections
             public void Dispose()
             {
 #if NET7_0_OR_GREATER
-                _countRef = ref Unsafe.AsRef<int>(IntPtr.Zero.ToPointer());
+                _countRef = ref Unsafe.NullRef<int>();
 #endif
                 _currentSegment = [];
                 _enumeratedCount = -1;

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -334,9 +334,9 @@ namespace Yuh.Collections
                     using var en = builder.GetSegmentEnumerator();
                     while (en.MoveNext())
                     {
-                        int estCnt = decoder.GetCharCount(en.Current, false);
+                        int estCnt = decoder.GetCharCount(en.CurrentSpan, false);
                         char[] chars = ArrayPool<char>.Shared.Rent(estCnt);
-                        int charsWritten = decoder.GetChars(en.Current, chars.AsSpan(), false);
+                        int charsWritten = decoder.GetChars(en.CurrentSpan, chars.AsSpan(), false);
 
                         strLen = checked(strLen + charsWritten);
                         decoded[decodedSegmentCount] = (chars, charsWritten);
@@ -396,8 +396,8 @@ namespace Yuh.Collections
                 return string.Empty;
             }
 
-#if NET9_0_OR_GREATER
             using var en = builder.GetSegmentEnumerator();
+#if NET9_0_OR_GREATER
             return string.Create(
                 builder.Count,
                 en,
@@ -405,7 +405,7 @@ namespace Yuh.Collections
                     int copiedCnt = 0;
                     while (enumerator.MoveNext())
             {
-                        var src = enumerator.Current;
+                        var src = enumerator.CurrentSpan;
                         src.CopyTo(dest[copiedCnt..]);
                         copiedCnt += src.Length;
                     }
@@ -416,10 +416,9 @@ namespace Yuh.Collections
             Span<ReadOnlyMemory<char>> segments = _segments.AsSpan();
             int segmentCount = 0;
 
-            using var en = builder.GetSegmentMemoryEnumerator();
             while (en.MoveNext())
             {
-                segments[segmentCount] = en.Current;
+                segments[segmentCount] = en.CurrentMemory;
                 segmentCount++;
             }
 
@@ -429,11 +428,11 @@ namespace Yuh.Collections
                 static (dest, stat) => {
                     int copiedCnt = 0;
                     foreach (var seg in stat.AsSpan())
-            {
+                    {
                         seg.Span.CopyTo(dest[copiedCnt..]);
                         copiedCnt += seg.Length;
                     }
-            }
+                }
             );
 #endif
         }

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -38,6 +38,72 @@ namespace Yuh.Collections
         }
 
         /// <summary>
+        /// Encodes a string into a UTF-8 string and appends the encoded string to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <param name="builder">A collection builder to add an encoded string to.</param>
+        /// <param name="s">
+        /// A string to add.
+        /// The value can be null or empty string.
+        /// </param>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(-1)]
+#endif
+        public static void AppendLiteral(ref this CollectionBuilder<byte> builder, string? s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return;
+            }
+            AppendLiteral(ref builder, s.AsSpan());
+        }
+
+        /// <summary>
+        /// Encodes a sequence of characters into a UTF-8 string and appends the encoded string to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <param name="builder">A collection builder to add an encoded string to.</param>
+        /// <param name="s">A sequence of characters to add.</param>
+        public static void AppendLiteral(ref this CollectionBuilder<byte> builder, scoped ReadOnlySpan<char> s)
+        {
+            if (s.IsEmpty)
+            {
+                return;
+            }
+
+            var maxByteLength = (long)s.Length * 3;
+            switch (maxByteLength)
+            {
+                case <= 1024:
+                {
+                    Span<byte> destination = stackalloc byte[(int)maxByteLength];
+                    var bytesWritten = Encoding.UTF8.GetBytes(s, destination);
+                    builder.AppendRange(destination[..bytesWritten]);
+                    break;
+                }
+                case <= (1 << 26):
+                {
+                    byte[] destination = ArrayPool<byte>.Shared.Rent((int)maxByteLength);
+                    try
+                    {
+                        var bytesWritten = Encoding.UTF8.GetBytes(s, destination.AsSpan());
+                        builder.AppendRange(destination.AsSpan()[..bytesWritten]);
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(destination);
+                    }
+                    break;
+                }
+                default:
+                {
+                    var bytes = new byte[Encoding.UTF8.GetByteCount(s)];
+                    var bytesWritten = Encoding.UTF8.GetBytes(s, bytes.AsSpan());
+                    builder.AppendRange(bytes.AsSpan()[..bytesWritten]);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
         /// Appends the string expression of the value to the back of the <see cref="CollectionBuilder{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
@@ -85,6 +151,86 @@ namespace Yuh.Collections
             else if (value is IFormattable valueFormattable)
             {
                 builder.AppendLiteral(valueFormattable.ToString(format.ToString(), provider));
+                return;
+            }
+
+            builder.AppendLiteral(value?.ToString());
+            return;
+        }
+
+        /// <summary>
+        /// Appends UTF-8 string expression of a value to the back of the <see cref="CollectionBuilder{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of value.</typeparam>
+        /// <param name="builder">A collection builder to add a string to.</param>
+        /// <param name="value">A value to write.</param>
+        /// <param name="estimatedStringLength">An estimated length of a string to add.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for the destination collection.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for the destination collection.</param>
+        public static void AppendUtf8Formatted<T>(ref this CollectionBuilder<byte> builder, T value, int estimatedStringLength = DefaultReserveLength, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+#if NET9_0_OR_GREATER
+            if (value is IUtf8SpanFormattable u8SpanFormattable)
+            {
+                int charsWritten;
+                int destLength = Math.Max(estimatedStringLength, 1);
+
+                if (destLength <= 1024)
+                {
+                    int totalAllocatedByteLength = 0;
+                    do
+                    {
+#pragma warning disable CA2014
+                        Span<byte> destination = stackalloc byte[destLength];
+#pragma warning restore CA2014
+                        if (u8SpanFormattable.TryFormat(destination, out charsWritten, format, provider))
+                        {
+                            builder.AppendRange(destination[..charsWritten]);
+                            return;
+                        }
+                        totalAllocatedByteLength += destLength;
+                        destLength <<= 1;
+                    }
+                    while (destLength <= 512 - totalAllocatedByteLength);
+                }
+
+                var reserved = builder.ReserveRange(destLength);
+                while (!u8SpanFormattable.TryFormat(reserved, out charsWritten, format, provider))
+                {
+                    builder.RemoveRange(destLength);
+                    destLength = checked(destLength << 1);
+                    reserved = builder.ReserveRange(destLength);
+                }
+                builder.RemoveRange(destLength - charsWritten);
+                return;
+            }
+#endif
+            if (value is IFormattable formattable)
+            {
+                if (formattable is ISpanFormattable spanFormattable)
+                {
+                    int destLength = Math.Max(estimatedStringLength, 1);
+
+                    if (destLength <= 512)
+                    {
+                        int totalAllocatedByteLength = 0;
+                        do
+                        {
+#pragma warning disable CA2014
+                            Span<char> destination = stackalloc char[destLength];
+#pragma warning restore CA2014
+                            if (spanFormattable.TryFormat(destination, out var charsWritten, format, provider))
+                            {
+                                builder.AppendLiteral(destination[..charsWritten]);
+                                return;
+                            }
+                            totalAllocatedByteLength += destLength;
+                            destLength <<= 1;
+                        }
+                        while (destLength <= 512 - totalAllocatedByteLength);
+                    }
+                }
+                builder.AppendLiteral(formattable.ToString(format.ToString(), provider));
                 return;
             }
 

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -298,6 +298,11 @@ namespace Yuh.Collections
             return list;
         }
 
+        /// <summary>
+        /// Creates a <see cref="string"/> from a collection builder that represents a UTF-8 encoded string.
+        /// </summary>
+        /// <param name="builder">A <see cref="CollectionBuilder{T}"/> that represents a UTF-8 encoded string to create a <see cref="string"/> from.</param>
+        /// <returns>A <see cref="string"/> converted from the UTF-8 encoded string that the collection builder represents.</returns>
         public static string ToSystemString(in this CollectionBuilder<byte> builder)
         {
             int length = builder.Count;

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -303,7 +303,7 @@ namespace Yuh.Collections
         /// </summary>
         /// <param name="builder">A <see cref="CollectionBuilder{T}"/> whose elements (characters) are copied to the new <see cref="string"/>.</param>
         /// <returns>A <see cref="string"/> which contains characters are copied from the <see cref="CollectionBuilder{T}"/>.</returns>
-        public static string ToBasicString(in this CollectionBuilder<char> builder)
+        public static string ToSystemString(in this CollectionBuilder<char> builder)
         {
             if (builder.Count == 0)
             {

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -320,7 +320,7 @@ namespace Yuh.Collections
                     try
                     {
                         builder.CopyTo(bytes.AsSpan());
-                        return Encoding.UTF8.GetString(bytes);
+                        return Encoding.UTF8.GetString(bytes[..builder.Count]);
                     }
                     finally
                     {


### PR DESCRIPTION
Close #37 

# What I did

- Add extension methods for `CollectionBuilder<byte>` structure.
  - `ToSystemString(in this CollectionBuilder<byte>)`
  - `AppendLiteral(ref this CollectionBuilder<byte>, string?)`
  - `AppendLiteral(ref this CollectionBuilder<byte>, scoped ReadOnlySpan<char>)`
  - `AppendUtf8Formatted<T>(ref this CollcetionBuilder<byte>, T value)`
- `CollectionBuilder<T>` structure provides enumerators that enumerate segments (as `ReadOnlySpan<T>`) in a collection builder.
- New structure type `CollectionBuilderConstants.Segments<T>` that hides difference between dotnet runtime version.
