### PR TITLE
Tests: add tests for extension methods for CollectionBuilder{byte} structure

### DIFF
--- a/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
+++ b/src/Yuh.Collections.Tests/CollectionBuilderExtensionsTest.cs
@@ -112,6 +112,29 @@ namespace Yuh.Collections.Tests
 
         [Theory]
         [ClassData(typeof(StringArrayData))]
+        public void ToStringFromUtf8StringTest(string[] data)
+        {
+            CollectionBuilder<byte> builder = [];
+            DefaultInterpolatedStringHandler handler = new(0, data.Length);
+
+            try
+            {
+                foreach (var str in data)
+                {
+                    builder.AppendLiteral(str);
+                    handler.AppendFormatted(str);
+                }
+
+                Assert.Equal(handler.ToStringAndClear(), builder.ToSystemString());
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(StringArrayData))]
         public void ToSystemStringTest(string[] items)
         {
             using CollectionBuilder<char> builder = new();

--- a/src/Yuh.Collections/CollectionBuilderExtensions.cs
+++ b/src/Yuh.Collections/CollectionBuilderExtensions.cs
@@ -320,7 +320,7 @@ namespace Yuh.Collections
                     try
                     {
                         builder.CopyTo(bytes.AsSpan());
-                        return Encoding.UTF8.GetString(bytes);
+                        return Encoding.UTF8.GetString(bytes.AsSpan()[..length]);
                     }
                     finally
                     {


### PR DESCRIPTION
# What I did

- Add a testing method for `CollectionBuilderExtensions.AppendLiteral(this CollectionBuilder<byte>, ReadOnlySpan<char>)` method.
- Fix a bug in `CollectionBuilderExtensions.ToSystemString(this CollectionBuilder<byte>)` method.